### PR TITLE
Fix doc for build.sh arguments

### DIFF
--- a/Quick start.md
+++ b/Quick start.md
@@ -14,7 +14,7 @@ You need to run the build script before you can use this repository. The reason 
 
 1. Open Terminal on macOS or Git Bash on Windows
 2. ```cd Source```
-3. Run ```./build.sh [Target platform]```. ```[Target platform]``` can be one or several of *macos, ios, Android, Windows*
+3. Run ```./build.sh [Target platform]```. ```[Target platform]``` can be one or several of *macos, ios, android, windows*
 
 This will fetch all the dependencies and place them inside the ```Plugins``` directory.
 


### PR DESCRIPTION
The "windows" and "android" arguments to build.sh are case sensitive. In the doc they were capitalized but in the script they are all lower case.