### PR TITLE
Added default video pixel format for Windows

### DIFF
--- a/Source/Package/Assets/artoolkitX-Unity/Scripts/ARController.cs
+++ b/Source/Package/Assets/artoolkitX-Unity/Scripts/ARController.cs
@@ -110,7 +110,7 @@ public class ARController : MonoBehaviour
 
     // Config. in.
     public string videoCParamName0 = "";
-    public string videoConfigurationWindows0 = "-showDialog";
+    public string videoConfigurationWindows0 = "-format=BGRA";
     public string videoConfigurationMacOSX0 = "-width=640 -height=480";
     public string videoConfigurationiOS0 = "";
     public string videoConfigurationAndroid0 = "";
@@ -738,6 +738,45 @@ public class ARController : MonoBehaviour
         private int screenHeight = 0;
 #  endif
 #endif
+
+	//Returns the GameObject that is displaying video content.
+	public GameObject GetVideoObject()
+    {
+        return _videoBackgroundMeshGO0;
+    }
+
+	//Grab a copy of the current video texture.
+	// This function isn't as clean or efficient as it should be - there seem to be some access-right issues with the Unity texture. 
+    public Texture2D GetTexture()
+    {
+
+        // Create a temporary RenderTexture of the same size as the texture
+        RenderTexture tmp = RenderTexture.GetTemporary(
+                            _videoTexture0.width,
+                            _videoTexture0.height,
+                            0,
+                            RenderTextureFormat.Default,
+                            RenderTextureReadWrite.Linear);
+
+        // Blit the pixels on texture to the RenderTexture
+        Graphics.Blit(_videoTexture0, tmp);
+
+        // Backup the currently set RenderTexture
+        RenderTexture previous = RenderTexture.active;
+
+        Texture2D myTexture2D = new Texture2D(_videoTexture0.width, _videoTexture0.height);
+
+        // Copy the pixels from the RenderTexture to the new Texture
+        myTexture2D.ReadPixels(new Rect(0, 0, tmp.width, tmp.height), 0, 0);
+        myTexture2D.Apply();
+
+        // Reset the active RenderTexture
+        RenderTexture.active = previous;
+
+        RenderTexture.ReleaseTemporary(tmp);
+
+        return myTexture2D;
+    }
 
 
     bool UpdateAR()

--- a/Source/Package/Assets/artoolkitX-Unity/Scripts/Editor/ARCameraEditor.cs
+++ b/Source/Package/Assets/artoolkitX-Unity/Scripts/Editor/ARCameraEditor.cs
@@ -37,7 +37,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+//using System.Linq;
 using System.Text;
 using UnityEditor;
 using UnityEngine;
@@ -51,8 +51,14 @@ public class ARCameraEditor : Editor
 
     public static void RefreshOpticalParamsFilenames() 
 	{
-		OpticalParamsAssets = Resources.LoadAll("ardata/optical", typeof(TextAsset)).Cast<TextAsset>().ToArray();
-		OpticalParamsAssetCount = OpticalParamsAssets.Length;
+        //OpticalParamsAssets = Resources.LoadAll("ardata/optical", typeof(TextAsset)).Cast<TextAsset>().ToArray();
+        List<TextAsset> Markers = new List<TextAsset>();
+        foreach (object o in Resources.LoadAll("ardata/optical", typeof(TextAsset)))
+        {
+            Markers.Add((TextAsset)o);
+        }
+        OpticalParamsAssets = Markers.ToArray();
+        OpticalParamsAssetCount = OpticalParamsAssets.Length;
 		OpticalParamsFilenames = new string[OpticalParamsAssetCount];
 		for (int i = 0; i < OpticalParamsAssetCount; i++) {					
 			OpticalParamsFilenames[i] = OpticalParamsAssets[i].name;				

--- a/Source/Package/Assets/artoolkitX-Unity/Scripts/Editor/ARTrackableEditor.cs
+++ b/Source/Package/Assets/artoolkitX-Unity/Scripts/Editor/ARTrackableEditor.cs
@@ -37,7 +37,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+//using System.Linq;
 using System.Text;
 using UnityEditor;
 using UnityEngine;
@@ -76,7 +76,13 @@ public class ARTrackableEditor : Editor
 	
 	private static void RefreshPatternFilenames() 
 	{
-		PatternAssets = Resources.LoadAll("ardata/markers", typeof(TextAsset)).Cast<TextAsset>().ToArray();
+        List<TextAsset> Markers = new List<TextAsset>();
+        foreach(object o in Resources.LoadAll("ardata/markers", typeof(TextAsset)))
+        {
+            Markers.Add((TextAsset)o);
+        }
+        //PatternAssets = Resources.LoadAll("ardata/markers", typeof(TextAsset)).Cast<TextAsset>().ToArray();
+        PatternAssets = Markers.ToArray();
 		PatternAssetCount = PatternAssets.Length;
 		
 		PatternFilenames = new string[PatternAssetCount];


### PR DESCRIPTION
Added a 'format' directive to the default Windows video config (otherwise a crash will occur).
Added a couple of utility functions we routinely patch back into ARController - one to get the GameObject showing video, the other to grab a copy of the current video texture. 