### PR TITLE
- Add Android permissions request to StartAR.

### DIFF
--- a/Source/Package/Assets/artoolkitX-Unity/Plugins/Android/AndroidManifest.xml
+++ b/Source/Package/Assets/artoolkitX-Unity/Plugins/Android/AndroidManifest.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.Company.ProductName" xmlns:tools="http://schemas.android.com/tools">
-	<uses-permission android:name="android.permission.CAMERA" />
-	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-feature android:name="android.hardware.camera.any" />
-	<uses-feature android:name="android.hardware.camera" android:required="false" />
-	<uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
-</manifest>

--- a/Source/Package/Assets/artoolkitX-Unity/Plugins/Android/AndroidManifest.xml.meta
+++ b/Source/Package/Assets/artoolkitX-Unity/Plugins/Android/AndroidManifest.xml.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 0af04d8cb5f614e7aab77513483f163a
-timeCreated: 1519325008
-licenseType: Pro
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Source/Package/ProjectSettings/ProjectSettings.asset
+++ b/Source/Package/ProjectSettings/ProjectSettings.asset
@@ -13,7 +13,7 @@ PlayerSettings:
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: artoolkitX
-  productName: arxExample
+  productName: artoolkitX for Unity sample
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
@@ -154,12 +154,13 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
-    Android: org.artoolkitx.arx.example
+    Android: org.artoolkitx.arx.sample
+    iPhone: org.artoolkitx.arx.sample
   buildNumber:
     Standalone: 0
     iPhone: 0
     tvOS: 0
-  overrideDefaultApplicationIdentifier: 0
+  overrideDefaultApplicationIdentifier: 1
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 23
   AndroidTargetSdkVersion: 0
@@ -244,7 +245,7 @@ PlayerSettings:
   useCustomBaseGradleTemplate: 0
   useCustomGradlePropertiesTemplate: 0
   useCustomProguardFile: 0
-  AndroidTargetArchitectures: 5
+  AndroidTargetArchitectures: 3
   AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
@@ -771,7 +772,8 @@ PlayerSettings:
   scriptingDefineSymbols: {}
   additionalCompilerArguments: {}
   platformArchitecture: {}
-  scriptingBackend: {}
+  scriptingBackend:
+    Android: 0
   il2cppCompilerConfiguration: {}
   managedStrippingLevel:
     EmbeddedLinux: 1
@@ -797,7 +799,8 @@ PlayerSettings:
   gcIncremental: 1
   assemblyVersionValidation: 1
   gcWBarrierValidation: 0
-  apiCompatibilityLevelPerPlatform: {}
+  apiCompatibilityLevelPerPlatform:
+    Android: 6
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: ARTK5

--- a/Source/Package/ProjectSettings/UnityConnectSettings.asset
+++ b/Source/Package/ProjectSettings/UnityConnectSettings.asset
@@ -3,25 +3,26 @@
 --- !u!310 &1
 UnityConnectSettings:
   m_ObjectHideFlags: 0
+  serializedVersion: 1
   m_Enabled: 0
   m_TestMode: 0
-  m_TestEventUrl: 
-  m_TestConfigUrl: 
+  m_EventOldUrl: https://api.uca.cloud.unity3d.com/v1/events
+  m_EventUrl: https://cdp.cloud.unity3d.com/v1/events
+  m_ConfigUrl: https://config.uca.cloud.unity3d.com
+  m_DashboardUrl: https://dashboard.unity3d.com
   m_TestInitMode: 0
   CrashReportingSettings:
-    m_EventUrl: https://perf-events.cloud.unity3d.com/api/events/crashes
-    m_NativeEventUrl: https://perf-events.cloud.unity3d.com/symbolicate
+    m_EventUrl: https://perf-events.cloud.unity3d.com
     m_Enabled: 0
+    m_LogBufferSize: 10
     m_CaptureEditorExceptions: 1
   UnityPurchasingSettings:
     m_Enabled: 0
     m_TestMode: 0
   UnityAnalyticsSettings:
     m_Enabled: 0
-    m_InitializeOnStartup: 1
     m_TestMode: 0
-    m_TestEventUrl: 
-    m_TestConfigUrl: 
+    m_InitializeOnStartup: 1
   UnityAdsSettings:
     m_Enabled: 0
     m_InitializeOnStartup: 1


### PR DESCRIPTION
- StartAR now co-routine.
- Don't call to StartAR from UpdateAR.
- Remove AndroidManifest.xml and replace with build post-processor to insert required permissions and features into manifest.
- Tweak built sample app packge ID.

Fixes #62 