### PR TITLE
Fixes for first run.

### DIFF
--- a/Packages/artoolkitX-Unity/Editor/Scripts/ARToolKitEditorSettings.cs
+++ b/Packages/artoolkitX-Unity/Editor/Scripts/ARToolKitEditorSettings.cs
@@ -125,15 +125,8 @@ class ARToolKitEditorSettingsProvider : SettingsProvider
     {
         if (m_CustomSettings.FindProperty("m_allowUnityVideoProviders").boolValue)
         {
+            // Don't need to set PlayerSettings.allowUnsafeCode = true anymore since the unsafe code is in its own assembly.
             ARToolKitEditorUtilities.ChangeScriptingDefine("ARX_ALLOW_UNITY_VIDEO_PROVIDERS", ARToolKitEditorUtilities.AddOrRemove.Add);
-            try
-            {
-                PlayerSettings.allowUnsafeCode = true;
-            }
-            catch (Exception e)
-            {
-                Debug.LogError($"Error {e} setting PlayerSettings.allowUnsafeCode");
-            }
         }
         else
         {

--- a/Packages/artoolkitX-Unity/Editor/Scripts/ARToolKitEditorUtilities.cs
+++ b/Packages/artoolkitX-Unity/Editor/Scripts/ARToolKitEditorUtilities.cs
@@ -46,6 +46,14 @@ public class ARToolKitEditorUtilities
         Remove
     }
 
+    public static bool HasScriptingDefine(string define)
+    {
+        BuildTargetGroup buildTargetGroup = EditorUserBuildSettings.selectedBuildTargetGroup;
+        string definesString = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
+        List<string> allDefines = definesString.Split(';').ToList();
+        return allDefines.Contains(define);
+    }
+
     public static void ChangeScriptingDefine(string define, AddOrRemove addOrRemove)
     {
         BuildTargetGroup buildTargetGroup = EditorUserBuildSettings.selectedBuildTargetGroup;

--- a/Packages/artoolkitX-Unity/Editor/Scripts/ARToolKitMenuEditor.cs
+++ b/Packages/artoolkitX-Unity/Editor/Scripts/ARToolKitMenuEditor.cs
@@ -29,16 +29,15 @@
  *  statement from your version.
  *
  *  Copyright 2015 Daqri, LLC.
+ *  Copyright 2023 Philip Lamb
  *
- *  Author(s): Wally Young
+ *  Author(s): Wally Young, Philip Lamb.
  *
  */
 
 
 using UnityEngine;
 using UnityEditor;
-using System.IO;
-using System.Text.RegularExpressions;
 
 [InitializeOnLoad]
 public class ARToolKitMenuEditor : MonoBehaviour {
@@ -56,15 +55,6 @@ public class ARToolKitMenuEditor : MonoBehaviour {
     private const string GET_TOOLS_MESSAGE     = "To make your own square pictorial markers or calibrate your camera, you'll need to download the tools.";
     private const string WINDOWS_RUNTIME_MESSAGE = "artoolkitX requires the Microsoft C++ Redistributables to be installed on your system.";
 
-    static ARToolKitMenuEditor() {
-        SerializedObject s = ARToolKitEditorSettings.GetSerializedSettings();
-        SerializedProperty hideWelcome = s.FindProperty("m_hideWelcome");
-        if (!hideWelcome.boolValue)
-        {
-            EditorWindow.GetWindow(typeof(ARToolKitWelcomeWindow));
-        }
-    }
-    
     [MenuItem (VERSION_MENU, false, 0)]
     private static void Version() { }
 
@@ -111,8 +101,25 @@ public class ARToolKitMenuEditor : MonoBehaviour {
         Application.OpenURL(PLUGIN_SOURCE_URL);
     }
 
+    [InitializeOnLoad]
     class ARToolKitWelcomeWindow : EditorWindow
     {
+        static ARToolKitWelcomeWindow()
+        {
+            EditorApplication.update += OnEditorStart;
+        }
+
+        static void OnEditorStart()
+        {
+            EditorApplication.update -= OnEditorStart;
+            SerializedObject s = ARToolKitEditorSettings.GetSerializedSettings();
+            SerializedProperty hideWelcome = s.FindProperty("m_hideWelcome");
+            if (!s.FindProperty("m_hideWelcome").boolValue)
+            {
+                EditorWindow.GetWindow(typeof(ARToolKitWelcomeWindow));
+            }
+        }
+
         private void OnGUI()
         {
             SerializedObject s = ARToolKitEditorSettings.GetSerializedSettings();

--- a/Packages/artoolkitX-Unity/Runtime/org.artoolkitx.artoolkitx-unity.asmdef
+++ b/Packages/artoolkitX-Unity/Runtime/org.artoolkitx.artoolkitx-unity.asmdef
@@ -12,7 +12,7 @@
         "WindowsStandalone64"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/Packages/artoolkitX-Unity/Samples/BarcodeSample/BarcodeSceneSettings.lighting
+++ b/Packages/artoolkitX-Unity/Samples/BarcodeSample/BarcodeSceneSettings.lighting
@@ -6,7 +6,7 @@ LightingSettings:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: SquareBarcodeMarkerSceneSettings
+  m_Name: BarcodeSceneSettings
   serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1

--- a/Packages/artoolkitX-Unity/Samples/CubeSample/CubeSceneSettings.lighting
+++ b/Packages/artoolkitX-Unity/Samples/CubeSample/CubeSceneSettings.lighting
@@ -6,7 +6,7 @@ LightingSettings:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: CubemarkerSceneSettings
+  m_Name: CubeSceneSettings
   serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1

--- a/Packages/artoolkitX-Unity/Samples/LegacyNFTSample/LegacyNFTSceneSettings.lighting
+++ b/Packages/artoolkitX-Unity/Samples/LegacyNFTSample/LegacyNFTSceneSettings.lighting
@@ -6,7 +6,7 @@ LightingSettings:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: LegacyNFTMarkerSceneSettings
+  m_Name: LegacyNFTSceneSettings
   serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1

--- a/Packages/artoolkitX-Unity/Samples/MultimarkerSheetSample/MultimarkerSheetSceneSettings.lighting
+++ b/Packages/artoolkitX-Unity/Samples/MultimarkerSheetSample/MultimarkerSheetSceneSettings.lighting
@@ -6,7 +6,7 @@ LightingSettings:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: SquareMultimarkerSceneSettings
+  m_Name: MultimarkerSheetSceneSettings
   serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1

--- a/Packages/artoolkitX-Unity/Samples/SquareSample/SquareSceneSettings.lighting
+++ b/Packages/artoolkitX-Unity/Samples/SquareSample/SquareSceneSettings.lighting
@@ -6,7 +6,7 @@ LightingSettings:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: SquarePictorialMarkerSceneSettings
+  m_Name: SquareSceneSettings
   serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1

--- a/Packages/artoolkitX-Unity/Samples/StereoVideoPassthroughSample/StereoVideoSceneSettings.lighting
+++ b/Packages/artoolkitX-Unity/Samples/StereoVideoPassthroughSample/StereoVideoSceneSettings.lighting
@@ -6,7 +6,7 @@ LightingSettings:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: StereoSceneSettings
+  m_Name: StereoVideoSceneSettings
   serializedVersion: 4
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "com.unity.2d.sprite": "1.0.0",
+    "com.unity.2d.tilemap": "1.0.0",
     "com.unity.analytics": "3.6.12",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -6,6 +6,12 @@
       "source": "builtin",
       "dependencies": {}
     },
+    "com.unity.2d.tilemap": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
     "com.unity.analytics": {
       "version": "3.6.12",
       "depth": 0,

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -800,7 +800,7 @@ PlayerSettings:
     tvOS: 1
   incrementalIl2cppBuild: {}
   suppressCommonWarnings: 1
-  allowUnsafeCode: 1
+  allowUnsafeCode: 0
   useDeterministicCompilation: 1
   enableRoslynAnalyzers: 1
   selectedPlatform: 0

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -103,7 +103,7 @@ else
     CPUS=1
 fi
 
-ARTOOLKITX_VERSION=$(cat ${OURDIR}/artoolkitx-version.txt)
+ARTOOLKITX_VERSION=$(cat ${OURDIR}/artoolkitx-version.txt | tr -d '[:space:]')
 
 # Locate ARTOOLKITX_HOME or clone into submodule
 locate_artoolkitx() {


### PR DESCRIPTION
- Ensure EditorWindow only opens once editor is inited.
- Handle whitespace in artoolkit-version.txt
- Fixup object name in lighting settings.
- Correct issue with unsfe code warning.